### PR TITLE
Edit menu and add discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Support
-    url: https://discord.gg/EwFs3Pp
+    url: https://chat.gnosis.io
     about: Please ask and answer questions here
   - name: List a token
     url: https://github.com/Uniswap/default-token-list#adding-a-token

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An open source fork of Uniswap to Swap in Gnosis Protocol v2 -- a protocol for d
 
 - Twitter: [@gnosisPM](https://twitter.com/gnosisPM)
 - Reddit: [/r/gnosisPM](https://www.reddit.com/r/gnosisPM)
-- Discord: [Gnosis](https://discord.com/invite/M39dTHQ)
+- Discord: [Uniswap](https://chat.gnosis.io)
 
 ## Development
 

--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -1,0 +1,139 @@
+import React, { useRef } from 'react'
+// import { BookOpen, Code, Info, MessageCircle, PieChart } from 'react-feather'
+import styled from 'styled-components'
+import { ReactComponent as MenuIcon } from 'assets/images/menu.svg'
+// import { useActiveWeb3React } from 'hooks'
+import { useOnClickOutside } from 'hooks/useOnClickOutside'
+import { ApplicationModal } from 'state/application/actions'
+import { useModalOpen, useToggleModal } from 'state/application/hooks'
+
+import { ExternalLink } from 'theme'
+import { WithChildren } from 'types'
+// import { ButtonPrimary } from 'Button'
+
+const StyledMenuIcon = styled(MenuIcon)`
+  path {
+    stroke: ${({ theme }) => theme.text1};
+  }
+`
+
+export const StyledMenuButton = styled.button`
+  width: 100%;
+  height: 100%;
+  border: none;
+  background-color: transparent;
+  margin: 0;
+  padding: 0;
+  height: 35px;
+  background-color: ${({ theme }) => theme.bg3};
+
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.5rem;
+
+  :hover,
+  :focus {
+    cursor: pointer;
+    outline: none;
+    background-color: ${({ theme }) => theme.bg4};
+  }
+
+  svg {
+    margin-top: 2px;
+  }
+`
+
+export const StyledMenu = styled.div`
+  margin-left: 0.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  border: none;
+  text-align: left;
+`
+
+export const MenuFlyout = styled.span`
+  min-width: 8.125rem;
+  background-color: ${({ theme }) => theme.bg3};
+  box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.01), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
+    0px 24px 32px rgba(0, 0, 0, 0.01);
+  border-radius: 12px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  font-size: 1rem;
+  position: absolute;
+  top: 4rem;
+  right: 0rem;
+  z-index: 100;
+
+  ${({ theme }) => theme.mediaWidth.upToMedium`
+    top: -17.25rem;
+  `};
+`
+
+export const MenuItem = styled(ExternalLink)`
+  flex: 1;
+  padding: 0.5rem 0.5rem;
+  color: ${({ theme }) => theme.text2};
+  :hover {
+    color: ${({ theme }) => theme.text1};
+    cursor: pointer;
+    text-decoration: none;
+  }
+  > svg {
+    margin-right: 8px;
+  }
+`
+
+// const CODE_LINK = 'https://github.com/Uniswap/uniswap-interface'
+
+export default function Menu(props?: WithChildren) {
+  // const { account } = useActiveWeb3React()
+
+  const node = useRef<HTMLDivElement>()
+  const open = useModalOpen(ApplicationModal.MENU)
+  const toggle = useToggleModal(ApplicationModal.MENU)
+  useOnClickOutside(node, open ? toggle : undefined)
+  // const openClaimModal = useToggleModal(ApplicationModal.ADDRESS_CLAIM)
+
+  return (
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/30451
+    <StyledMenu ref={node as any}>
+      <StyledMenuButton onClick={toggle}>
+        <StyledMenuIcon />
+      </StyledMenuButton>
+
+      {open && (
+        <MenuFlyout>
+          {props?.children}
+          {/* <MenuItem id="link" href="https://uniswap.org/">
+            <Info size={14} />
+            About
+          </MenuItem>
+          <MenuItem id="link" href="https://uniswap.org/docs/v2">
+            <BookOpen size={14} />
+            Docs
+          </MenuItem>
+          <MenuItem id="link" href={CODE_LINK}>
+            <Code size={14} />
+            Code
+          </MenuItem>
+          <MenuItem id="link" href="https://discord.gg/EwFs3Pp">
+            <MessageCircle size={14} />
+            Discord
+          </MenuItem>
+          <MenuItem id="link" href="https://uniswap.info/">
+            <PieChart size={14} />
+            Analytics
+          </MenuItem>
+          {account && (
+            <ButtonPrimary onClick={openClaimModal} padding="8px 16px" width="100%" borderRadius="12px" mt="0.5rem">
+              Claim UNI
+            </ButtonPrimary>
+          )} */}
+        </MenuFlyout>
+      )}
+    </StyledMenu>
+  )
+}

--- a/src/custom/components/Menu/MenuMod.tsx
+++ b/src/custom/components/Menu/MenuMod.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { PropsWithChildren, useRef } from 'react'
 // import { BookOpen, Code, Info, MessageCircle, PieChart } from 'react-feather'
 import styled from 'styled-components'
 import { ReactComponent as MenuIcon } from 'assets/images/menu.svg'
@@ -8,7 +8,6 @@ import { ApplicationModal } from 'state/application/actions'
 import { useModalOpen, useToggleModal } from 'state/application/hooks'
 
 import { ExternalLink } from 'theme'
-import { WithChildren } from 'types'
 // import { ButtonPrimary } from 'Button'
 
 const StyledMenuIcon = styled(MenuIcon)`
@@ -88,7 +87,7 @@ export const MenuItem = styled(ExternalLink)`
 
 // const CODE_LINK = 'https://github.com/Uniswap/uniswap-interface'
 
-export default function Menu(props?: WithChildren) {
+export default function Menu(props?: PropsWithChildren<void>) {
   // const { account } = useActiveWeb3React()
 
   const node = useRef<HTMLDivElement>()

--- a/src/custom/components/Menu/index.tsx
+++ b/src/custom/components/Menu/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Code, MessageCircle, PieChart } from 'react-feather'
+
+import MenuMod, { MenuItem } from './MenuMod'
+import styled from 'styled-components'
+
+const CODE_LINK = 'https://github.com/gnosis/dex-swap'
+const DISCORD_LINK = 'https://chat.gnosis.io'
+
+export const StyledMenu = styled(MenuMod)``
+
+export function Menu() {
+  return (
+    <StyledMenu>
+      <MenuItem id="link" href={CODE_LINK}>
+        <Code size={14} />
+        Code
+      </MenuItem>
+      <MenuItem id="link" href={DISCORD_LINK}>
+        <MessageCircle size={14} />
+        Discord
+      </MenuItem>
+      <MenuItem id="link" href="https://uniswap.info/">
+        <PieChart size={14} />
+        Analytics
+      </MenuItem>
+    </StyledMenu>
+  )
+}
+
+export default Menu

--- a/src/custom/types.ts
+++ b/src/custom/types.ts
@@ -1,7 +1,3 @@
 export interface WithClassName {
   className?: string
 }
-
-export interface WithChildren {
-  children: React.ReactNode
-}

--- a/src/custom/types.ts
+++ b/src/custom/types.ts
@@ -1,3 +1,7 @@
 export interface WithClassName {
   className?: string
 }
+
+export interface WithChildren {
+  children: React.ReactNode
+}


### PR DESCRIPTION
Hacks the Menu, this one I took a different approach.

To avoid modifing stuff in the "Mod" version, I just added "children" prop to the "Mod" so now we can define the items in the component under our control

This PR cleanups the menu from the unneeded things, and updates the links to our discord.

![image](https://user-images.githubusercontent.com/2352112/97599130-f2785e00-1a07-11eb-813e-f00dc750df01.png)

![image](https://user-images.githubusercontent.com/2352112/97600200-18523280-1a09-11eb-938a-4967ea4237f8.png)
