### PR TITLE
Fix rgba format

### DIFF
--- a/src/custom/theme/index.tsx
+++ b/src/custom/theme/index.tsx
@@ -44,7 +44,7 @@ export function colors(darkMode: boolean): Colors {
     // primary2: darkMode ? '#3680E7' : '#FF8CC3',
     // primary3: darkMode ? '#4D8FEA' : '#FF99C9',
     // primary4: darkMode ? '#376bad70' : '#F6DDE8',
-    primary5: darkMode ? '#153d6f70' : 'rgb(137 88 255 / 15%);',
+    primary5: darkMode ? '#153d6f70' : 'rgba(137,88,255,0.6)',
 
     // ****** color text ******
     primaryText1: darkMode ? '#6da8ff' : '#8958FF',
@@ -52,7 +52,7 @@ export function colors(darkMode: boolean): Colors {
     // ****** secondary colors ******
     secondary1: darkMode ? '#2172E5' : '#8958FF',
     // secondary2: darkMode ? '#17000b26' : '#F6DDE8',
-    secondary3: darkMode ? '#17000b26' : 'rgb(137 88 255 / 15%);',
+    secondary3: darkMode ? '#17000b26' : 'rgba(137,88,255,0.6)',
 
     // ****** other ******
     // red1: '#FF6871',


### PR DESCRIPTION
Styled-components breaks when using light mode
Because [`polished.parseToRgb`](https://polished.js.org/docs/#parsetorgb) is very particular about what it accepts as input

Also, :sun_with_face: : THIS IS DISCRIMINATION :new_moon:  against people who prefer light mode :angry: 